### PR TITLE
Fixed webpack cli issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "^2.8.3",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.7.0",
-    "webpack-cli": "^2.1.3",
+    "webpack-cli": "^3.1.1",
     "yaml-cfn": "^0.2.0"
   },
   "jest": {


### PR DESCRIPTION
When doing yarn install with old versions of webpack cli, it fails.

This patch fixes that